### PR TITLE
changed onError to this.onError in FileHandler handleFileSelected

### DIFF
--- a/src/handlers/file-handler.js
+++ b/src/handlers/file-handler.js
@@ -56,7 +56,7 @@ export class FileHandler
 
             if(this.maxFileSize && f.size >= this.maxFileSize)
             {
-                if(onError)
+                if(this.onError)
                 { this.onError(f, "File exceeds file size limit"); }
                 continue;
             }


### PR DESCRIPTION
Was getting an onError not defined error when maxFileSize was exceeded due to missing this.
