### PR TITLE
Prevent undefined errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-files",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "registry": "jspm",
   "description": "A simple attribute plugin for Aurelia to simplify loading files with the HTML5 FileReader",
   "keywords": [

--- a/src/handlers/file-handler.js
+++ b/src/handlers/file-handler.js
@@ -45,7 +45,14 @@ export class FileHandler
 
     handleFileSelected = (fileSelectionEvent) =>
     {
-        var files = fileSelectionEvent.target.files || fileSelectionEvent.dataTransfer.files;
+        // prevent undefined errors
+        if (!fileSelectionEvent.target) {
+            fileSelectionEvent.target = {};
+        }
+        if (!fileSelectionEvent.dataTransfer) {
+            fileSelectionEvent.dataTransfer = {};
+        }
+        var files = fileSelectionEvent.target.files || fileSelectionEvent.dataTransfer.files || [];
         for (let i = 0, f; f = files[i]; i++) {
             if (this.fileFilter && !f.type.match(this.fileFilter))
             {


### PR DESCRIPTION
I had a situation where handleFileSelected was called where fileSelectionEvent.target was undefined, this resulted in a javascript error.